### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ ecm_find_qmlmodule(QtSensors 5.3)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-compass.in
+	${CMAKE_BINARY_DIR}/asteroid-compass
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-compass
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-compass)
 

--- a/asteroid-compass.desktop.template
+++ b/asteroid-compass.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-compass
+Exec=asteroid-compass
 Icon=ios-compass-outline
 X-Asteroid-Center-Color=#29A600
 X-Asteroid-Outer-Color=#070C00

--- a/asteroid-compass.in
+++ b/asteroid-compass.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-compass.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-compass main.cpp resources.qrc)
-set_target_properties(asteroid-compass PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-compass PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-compass PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-compass
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker