### PR TITLE
Refactor compass for smoother rotation and cleaner structure

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2022 - Darrel Griët    <dgriet@gmail.com>
+ * Copyright (C) 2026 - Timo Könnecke   <github.com/moWerk>
+ *               2022 - Darrel Griët    <dgriet@gmail.com>
  *               2017 - Florent Revest  <revestflo@gmail.com>
  *                    - Niels Tholenaar <info@123quality.nl>
  *
@@ -28,9 +29,8 @@ Application {
     centerColor: "#29A600"
     outerColor: "#070C00"
 
-    property int rotation: 0;
-    property int calibration: 0;
-    property int ringValueOffset: Math.sqrt(Math.pow(Dims.l(40), 2) / 2);
+    property real rotation: 0
+    property int calibration: 0
 
     Compass {
         active: true
@@ -57,20 +57,7 @@ Application {
             Label {
                 id: magneticRotation
                 anchors.centerIn: parent
-                text: app.rotation
-                font {
-                    pixelSize: parent.height / 4
-                    capitalization: Font.Capitalize
-                    styleName: "SemiCondensed"
-                    kerning: true
-                    preferShaping: true
-                }
-            }
-            Label {
-                id: degreeSymbol
-                anchors.top: magneticRotation.top
-                anchors.left: magneticRotation.right
-                text: "°"
+                text: Math.round(app.rotation) + "°"
                 font {
                     pixelSize: parent.height / 4
                     capitalization: Font.Capitalize
@@ -80,7 +67,6 @@ Application {
                 }
             }
             Image {
-                anchors.top: parent.top
                 anchors.centerIn: parent
                 anchors.verticalCenterOffset: -Dims.l(35)
                 width: Dims.l(10)
@@ -94,7 +80,6 @@ Application {
             rotation: -app.rotation
             Repeater {
                 id: outerRing
-                anchors.fill: parent
                 model: 8
                 Label {
                     property var angle: (index / outerRing.count) * 2 * Math.PI


### PR DESCRIPTION
Fixes the flickering/instability reported in the issue.

Fixes: https://github.com/AsteroidOS/asteroid-compass/issues/9

## Changes

**Rotation fix**
The azimuth property was stored as `int`, causing UI elements to snap between whole-degree steps on every sensor tick. Changing it to `real` lets QML rotate elements at full float precision, eliminating the visible stepping.

**Display**
Fractional degree display was considered but the QtSensors driver returns `azimuth` already integer-truncated, so `.toFixed(1)` always yielded `.0`. The display now uses `Math.round()` to stay honest about the sensor's actual resolution.

**Cleanup**
- Merged `degreeSymbol` label into `magneticRotation`, removing a duplicated font block and potential alignment drift
- Removed conflicting `anchors.top` from the compass needle image (conflicted with `anchors.centerIn`)
- Removed no-op `anchors.fill` from the `Repeater` element
- Deleted unused `ringValueOffset` property